### PR TITLE
Add support for passing a singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Under the hood the official [mongodb](https://github.com/mongodb/node-mongodb-na
 npm i fastify-mongodb --save
 ```
 ## Usage
-Add it to you project with `register` and you are done!
+Add it to your project with `register` and you are done!  
 You can access the *Mongo* database via `fastify.mongo.db` and *ObjectId* via `fastify.mongo.ObjectId`.
 ```js
 const fastify = require('fastify')()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Under the hood the official [mongodb](https://github.com/mongodb/node-mongodb-na
 npm i fastify-mongodb --save
 ```
 ## Usage
-Add it to you project with `register` and you are done!  
+Add it to you project with `register` and you are done!
 You can access the *Mongo* database via `fastify.mongo.db` and *ObjectId* via `fastify.mongo.ObjectId`.
 ```js
 const fastify = require('fastify')()
@@ -38,6 +38,30 @@ fastify.listen(3000, err => {
   console.log(`server listening on ${fastify.server.address().port}`)
 })
 ```
+
+You may also supply a pre-configured instance of `mongodb.MongoClient`:
+
+```js
+const mongodb = require('mongodb')
+mongodb.MongoClient.connect('mongodb://mongo/db')
+  .then((db) => {
+    const fastify = require('fastify')()
+
+    fastify.register(require('fastify-mongodb'), {
+      client: db
+    })
+
+    // ...
+    // ...
+    // ...
+  })
+  .catch((err) => {
+    throw err
+  })
+```
+
+Note: the passed `db` connection will be closed when the Fastify server
+shutsdown.
 
 ## Acknowledgements
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,22 @@ const MongoClient = MongoDb.MongoClient
 const ObjectId = MongoDb.ObjectId
 
 function fastifyMongodb (fastify, options, next) {
+  if (options.client) {
+    const db = options.client
+    delete options.client
+    const mongo = {
+      db: db,
+      ObjectId: ObjectId
+    }
+    if (options.name) {
+      mongo[options.name] = mongo
+      delete options.name
+    }
+    fastify.decorate('mongo', mongo)
+    fastify.addHook('onClose', (fastify, done) => db.close(done))
+    return next()
+  }
+
   const url = options.url
   delete options.url
 

--- a/test.js
+++ b/test.js
@@ -146,3 +146,29 @@ test('fastify.mongo.db should be the mongo database client', t => {
     })
   })
 })
+
+test('accepts a pre-configured mongo database client', t => {
+  t.plan(3)
+
+  const mongodb = require('mongodb')
+  mongodb.MongoClient.connect('mongodb://127.0.0.1/test')
+    .then((db) => {
+      const fastify = Fastify()
+      fastify.register(fastifyMongo, {client: db, name: 'test'})
+
+      fastify.ready(err => {
+        t.error(err)
+
+        const db = fastify.mongo.test.db
+        const col = db.collection('test')
+
+        col.insertOne({ a: 1 }, (err, r) => {
+          t.error(err)
+          t.equal(1, r.insertedCount)
+
+          fastify.close()
+        })
+      })
+    })
+    .catch(t.threw)
+})


### PR DESCRIPTION
This PR adds a `client` configuration option that allows passing in a pre-configured instance of `MongoClient`.