### PR TITLE
Update deps and code for mongodb v3 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Under the hood the official [mongodb](https://github.com/mongodb/node-mongodb-na
 npm i fastify-mongodb --save
 ```
 ## Usage
-Add it to your project with `register` and you are done!  
+Add it to your project with `register` and you are done!
 You can access the *Mongo* database via `fastify.mongo.db` and *ObjectId* via `fastify.mongo.ObjectId`.
 ```js
 const fastify = require('fastify')()
@@ -21,7 +21,7 @@ fastify.register(require('fastify-mongodb'), {
 })
 
 fastify.get('/user/:id', (req, reply) => {
-  const { db } = fastify.mongo
+  const db = fastify.mongo.client.db('db')
   db.collection('users', onCollection)
 
   function onCollection (err, col) {
@@ -44,12 +44,10 @@ You may also supply a pre-configured instance of `mongodb.MongoClient`:
 ```js
 const mongodb = require('mongodb')
 mongodb.MongoClient.connect('mongodb://mongo/db')
-  .then((db) => {
+  .then((client) => {
     const fastify = require('fastify')()
 
-    fastify.register(require('fastify-mongodb'), {
-      client: db
-    })
+    fastify.register(require('fastify-mongodb'), {client})
 
     // ...
     // ...
@@ -60,7 +58,7 @@ mongodb.MongoClient.connect('mongodb://mongo/db')
   })
 ```
 
-Note: the passed `db` connection will be closed when the Fastify server
+Note: the passed `client` connection will be closed when the Fastify server
 shutsdown.
 
 ## Acknowledgements

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ const ObjectId = MongoDb.ObjectId
 
 function fastifyMongodb (fastify, options, next) {
   if (options.client) {
-    const db = options.client
+    const client = options.client
     delete options.client
     const mongo = {
-      db: db,
+      client: client,
       ObjectId: ObjectId
     }
     if (options.name) {
@@ -19,7 +19,7 @@ function fastifyMongodb (fastify, options, next) {
       delete options.name
     }
     fastify.decorate('mongo', mongo)
-    fastify.addHook('onClose', (fastify, done) => db.close(done))
+    fastify.addHook('onClose', (fastify, done) => client.close(done))
     return next()
   }
 
@@ -31,15 +31,15 @@ function fastifyMongodb (fastify, options, next) {
 
   MongoClient.connect(url, options, onConnect)
 
-  function onConnect (err, db) {
+  function onConnect (err, client) {
     if (err) return next(err)
 
     const mongo = {
-      db: db,
+      client: client,
       ObjectId: ObjectId
     }
 
-    fastify.addHook('onClose', (fastify, done) => db.close(done))
+    fastify.addHook('onClose', (fastify, done) => client.close(done))
 
     if (name) {
       if (!fastify.mongo) {
@@ -60,4 +60,7 @@ function fastifyMongodb (fastify, options, next) {
   }
 }
 
-module.exports = fp(fastifyMongodb, '>=0.13.1')
+module.exports = fp(fastifyMongodb, {
+  fastify: '>=0.39.0',
+  name: 'fastify-mongodb'
+})

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
   },
   "homepage": "https://github.com/fastify/fastify-mongodb#readme",
   "devDependencies": {
-    "fastify": "^0.39.0",
+    "fastify": "^0.39.1",
     "standard": "^10.0.3",
     "tap": "^11.0.1"
   },
   "dependencies": {
     "fastify-plugin": "^0.2.1",
-    "mongodb": "^2.2.33"
+    "mongodb": "^3.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -17,7 +17,7 @@ test('fastify.mongo should exist', t => {
   fastify.ready(err => {
     t.error(err)
     t.ok(fastify.mongo)
-    t.ok(fastify.mongo.db)
+    t.ok(fastify.mongo.client)
     t.ok(fastify.mongo.ObjectId)
 
     fastify.close()
@@ -50,7 +50,7 @@ test('fastify.mongo.ObjectId should be a mongo ObjectId', t => {
   })
 })
 
-test('fastify.mongo.db should be the mongo database client', t => {
+test('fastify.mongo.client should be the mongo database client', t => {
   t.plan(3)
 
   const fastify = Fastify()
@@ -62,7 +62,7 @@ test('fastify.mongo.db should be the mongo database client', t => {
   fastify.ready(err => {
     t.error(err)
 
-    const db = fastify.mongo.db
+    const db = fastify.mongo.client.db('test')
     const col = db.collection('test')
 
     col.insertOne({ a: 1 }, (err, r) => {
@@ -88,7 +88,7 @@ test('fastify.mongo.test should exist', t => {
     t.error(err)
     t.ok(fastify.mongo)
     t.ok(fastify.mongo.test)
-    t.ok(fastify.mongo.test.db)
+    t.ok(fastify.mongo.test.client)
     t.ok(fastify.mongo.test.ObjectId)
 
     fastify.close()
@@ -122,7 +122,7 @@ test('fastify.mongo.test.ObjectId should be a mongo ObjectId', t => {
   })
 })
 
-test('fastify.mongo.db should be the mongo database client', t => {
+test('fastify.mongo.client should be the mongo database client', t => {
   t.plan(3)
 
   const fastify = Fastify()
@@ -135,7 +135,7 @@ test('fastify.mongo.db should be the mongo database client', t => {
   fastify.ready(err => {
     t.error(err)
 
-    const db = fastify.mongo.test.db
+    const db = fastify.mongo.test.client.db('test')
     const col = db.collection('test')
 
     col.insertOne({ a: 1 }, (err, r) => {
@@ -152,14 +152,14 @@ test('accepts a pre-configured mongo database client', t => {
 
   const mongodb = require('mongodb')
   mongodb.MongoClient.connect('mongodb://127.0.0.1/test')
-    .then((db) => {
+    .then((client) => {
       const fastify = Fastify()
-      fastify.register(fastifyMongo, {client: db, name: 'test'})
+      fastify.register(fastifyMongo, {client: client, name: 'test'})
 
       fastify.ready(err => {
         t.error(err)
 
-        const db = fastify.mongo.test.db
+        const db = fastify.mongo.test.client.db('test')
         const col = db.collection('test')
 
         col.insertOne({ a: 1 }, (err, r) => {


### PR DESCRIPTION
This PR:

1. Updates the dependencies
1. Adds metadata to the `fastify-plugin` invocation
1. Updates the code to work with the new `mongodb` v3.0.x module

They completely changed the way the driver works around connecting and getting database references. At the time of this PR it is impossible to easily get a reference to the desired database simply by specifying a URL -- https://jira.mongodb.org/browse/NODE-1258 . Thus, this PR changes the stored object to the instance of `MongoClient`. It is left up to the user to invoke `client.db('name')` to get a reference to the desired database.

Given the way this now works, I think the `options.name` feature is obsolete. But I have left it in for review.