### PR TITLE
minimalling the imported package size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,15 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const MongoDb = require('mongodb')
-
-const MongoClient = MongoDb.MongoClient
-const ObjectId = MongoDb.ObjectId
+const { MongoClient, ObjectId } = require('mongodb')
 
 function fastifyMongodb (fastify, options, next) {
   if (options.client) {
     const db = options.client
     delete options.client
     const mongo = {
-      db: db,
-      ObjectId: ObjectId
+      db,
+      ObjectId
     }
     if (options.name) {
       mongo[options.name] = mongo
@@ -35,8 +32,8 @@ function fastifyMongodb (fastify, options, next) {
     if (err) return next(err)
 
     const mongo = {
-      db: db,
-      ObjectId: ObjectId
+      db,
+      ObjectId
     }
 
     fastify.addHook('onClose', (fastify, done) => db.close(done))


### PR DESCRIPTION

For minimalling the imported package size, why not use the destructing assignment syntax？
Just like that grammar:
![m ltg9q dcr4nb x xeq uv](https://user-images.githubusercontent.com/24207813/35391987-459b4172-021b-11e8-81f8-46200228945c.png)