### PR TITLE
Avoid modifying options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const urlModule = require('url')
-
+const omit = require('lodash.omit')
 const fp = require('fastify-plugin')
 const MongoDb = require('mongodb')
 
@@ -58,14 +58,12 @@ function fastifyMongodb (fastify, options, next) {
     return
   }
   const urlParsed = urlModule.parse(url)
-  delete options.url
 
   const name = options.name
-  delete options.name
 
   const databaseName = options.database || (urlParsed.pathname ? urlParsed.pathname.substr(1) : undefined)
-  delete options.database
 
+  options = omit(options, ['url', 'name', 'database'])
   MongoClient.connect(url, options, function onConnect (err, client) {
     if (err) {
       next(err)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const urlModule = require('url')
-const omit = require('lodash.omit')
 const fp = require('fastify-plugin')
 const MongoDb = require('mongodb')
 
@@ -47,6 +46,8 @@ function decorateFastifyInstance (fastify, client, options, next) {
 }
 
 function fastifyMongodb (fastify, options, next) {
+  options = Object.assign({}, options)
+
   if (options.client) {
     decorateFastifyInstance(fastify, options.client, options, next)
     return
@@ -58,12 +59,14 @@ function fastifyMongodb (fastify, options, next) {
     return
   }
   const urlParsed = urlModule.parse(url)
+  delete options.url
 
   const name = options.name
+  delete options.name
 
   const databaseName = options.database || (urlParsed.pathname ? urlParsed.pathname.substr(1) : undefined)
+  delete options.database
 
-  options = omit(options, ['url', 'name', 'database'])
   MongoClient.connect(url, options, function onConnect (err, client) {
     if (err) {
       next(err)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "dependencies": {
     "fastify-plugin": "^0.2.1",
-    "lodash.omit": "^4.5.0",
     "mongodb": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^0.2.1",
+    "lodash.omit": "^4.5.0",
     "mongodb": "^3.0.1"
   }
 }

--- a/test.js
+++ b/test.js
@@ -364,6 +364,20 @@ test('double register with the same name', t => {
     })
 })
 
+test('Immutable options', t => {
+  t.plan(2)
+
+  const given = { url: MONGODB_URL, name: CLIENT_NAME, database: DATABASE_NAME }
+  register(t, given, function (err, fastify) {
+    t.error(err)
+    t.deepEqual(given, {
+      url: MONGODB_URL,
+      name: CLIENT_NAME,
+      database: DATABASE_NAME
+    })
+  })
+})
+
 function register (t, options, callback) {
   const fastify = Fastify()
   t.teardown(() => fastify.close())


### PR DESCRIPTION
Leaves the options untouched. Helps in cases where the options object may be reused or shared in a larger app.

Introduces dependency: `lodash.omit`