### PR TITLE
Fix/database name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const urlModule = require('url')
 const fp = require('fastify-plugin')
 const MongoDb = require('mongodb')
 
@@ -57,17 +56,19 @@ function fastifyMongodb (fastify, options, next) {
   }
 
   const url = options.url
+  delete options.url
   if (!url) {
     next(new Error('`url` parameter is mandatory if no client is provided'))
     return
   }
-  const urlParsed = urlModule.parse(url)
-  delete options.url
+
+  const urlTokens = /\w\/([^?]*)/g.exec(url)
+  const parsedDbName = urlTokens && urlTokens[1]
 
   const name = options.name
   delete options.name
 
-  const databaseName = options.database || (urlParsed.pathname ? urlParsed.pathname.substr(1) : undefined)
+  const databaseName = options.database || parsedDbName
   delete options.database
 
   MongoClient.connect(url, options, function onConnect (err, client) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-mongodb",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Fastify MongoDB connection plugin",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-mongodb",
-  "version": "0.7.1",
+  "version": "0.7.0",
   "description": "Fastify MongoDB connection plugin",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -14,8 +14,6 @@ const CLIENT_NAME = 'client_name'
 const ANOTHER_DATABASE_NAME = 'my_awesome_database'
 const COLLECTION_NAME = 'mycoll'
 const MULTIMONGODB_URL = 'mongodb://127.0.0.1:27017,127.0.0.1:27017,127.0.0.1:27017/' + DATABASE_NAME
-// const REPLICATED_DATABASE_MONGODB_URL = 'mongodb://user1:Passw0rd1@hostname1:27017,hostname2:27017,hostname:27017/' + DATABASE_NAME +
-//   '?replicaSet=myReplicaSet1&poolSize=25&readPreference=primaryPreferred&appname=myApp'
 
 test('{ url: NO_DATABASE_MONGODB_URL }', t => {
   t.plan(5 + 4 + 2)

--- a/test.js
+++ b/test.js
@@ -13,6 +13,9 @@ const MONGODB_URL = 'mongodb://127.0.0.1/' + DATABASE_NAME
 const CLIENT_NAME = 'client_name'
 const ANOTHER_DATABASE_NAME = 'my_awesome_database'
 const COLLECTION_NAME = 'mycoll'
+const MULTIMONGODB_URL = 'mongodb://127.0.0.1:27017,127.0.0.1:27017,127.0.0.1:27017/' + DATABASE_NAME
+// const REPLICATED_DATABASE_MONGODB_URL = 'mongodb://user1:Passw0rd1@hostname1:27017,hostname2:27017,hostname:27017/' + DATABASE_NAME +
+//   '?replicaSet=myReplicaSet1&poolSize=25&readPreference=primaryPreferred&appname=myApp'
 
 test('{ url: NO_DATABASE_MONGODB_URL }', t => {
   t.plan(5 + 4 + 2)
@@ -33,6 +36,23 @@ test('{ url: MONGODB_URL }', t => {
   t.plan(6 + 4 + 2 + 2)
 
   register(t, { url: MONGODB_URL }, function (err, fastify) {
+    t.error(err)
+    t.ok(fastify.mongo)
+    t.ok(fastify.mongo.client)
+    t.ok(fastify.mongo.ObjectId)
+    t.ok(fastify.mongo.db)
+    t.equal(fastify.mongo.db.s.databaseName, DATABASE_NAME)
+
+    testObjectId(t, fastify.mongo.ObjectId)
+    testClient(t, fastify.mongo.client)
+    testDatabase(t, fastify.mongo.db)
+  })
+})
+
+test('{ url: MULTIMONGODB_URL }', t => {
+  t.plan(6 + 4 + 2 + 2)
+
+  register(t, { url: MULTIMONGODB_URL }, function (err, fastify) {
     t.error(err)
     t.ok(fastify.mongo)
     t.ok(fastify.mongo.client)
@@ -303,7 +323,7 @@ test('{ client: client } does not set onClose', t => {
 
 test('{ }', t => {
   t.plan(2)
-  register(t, { }, function (err, fastify) {
+  register(t, {}, function (err, fastify) {
     t.ok(err)
     t.equal(err.message, '`url` parameter is mandatory if no client is provided')
   })


### PR DESCRIPTION
This PR fixes proper databaseName retrieval from urls that have multiple hostnames (in case of clustered mongodb). Addresses issue https://github.com/fastify/fastify-mongodb/issues/44