### PR TITLE
Update to mongodb 3.1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 
 node_js:
-  - "9"
+  - "11"
+  - "10"
   - "8"
   - "6"
-  - "10"
 
 services:
   - mongodb

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function decorateFastifyInstance (fastify, client, options, next) {
 }
 
 function fastifyMongodb (fastify, options, next) {
-  options = Object.assign({}, options)
+  options = Object.assign({ useNewUrlParser: true }, options)
 
   const forceClose = options.forceClose
   delete options.forceClose

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
   },
   "dependencies": {
     "fastify-plugin": "^1.0.1",
-    "mongodb": "^3.0.7"
+    "mongodb": "^3.1.8"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const { test, skip } = t
+const { test } = t
 const Fastify = require('fastify')
 const fastifyMongo = require('./index')
 
@@ -13,7 +13,6 @@ const MONGODB_URL = 'mongodb://127.0.0.1/' + DATABASE_NAME
 const CLIENT_NAME = 'client_name'
 const ANOTHER_DATABASE_NAME = 'my_awesome_database'
 const COLLECTION_NAME = 'mycoll'
-const MULTIMONGODB_URL = 'mongodb://127.0.0.1:27017,127.0.0.1:27017,127.0.0.1:27017/' + DATABASE_NAME
 
 test('{ url: NO_DATABASE_MONGODB_URL }', t => {
   t.plan(5 + 4 + 2)
@@ -34,23 +33,6 @@ test('{ url: MONGODB_URL }', t => {
   t.plan(6 + 4 + 2 + 2)
 
   register(t, { url: MONGODB_URL }, function (err, fastify) {
-    t.error(err)
-    t.ok(fastify.mongo)
-    t.ok(fastify.mongo.client)
-    t.ok(fastify.mongo.ObjectId)
-    t.ok(fastify.mongo.db)
-    t.equal(fastify.mongo.db.s.databaseName, DATABASE_NAME)
-
-    testObjectId(t, fastify.mongo.ObjectId)
-    testClient(t, fastify.mongo.client)
-    testDatabase(t, fastify.mongo.db)
-  })
-})
-
-skip('{ url: MULTIMONGODB_URL }', t => {
-  t.plan(6 + 4 + 2 + 2)
-
-  register(t, { url: MULTIMONGODB_URL }, function (err, fastify) {
     t.error(err)
     t.ok(fastify.mongo)
     t.ok(fastify.mongo.client)

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const t = require('tap')
-const test = t.test
+const { test, skip } = t
 const Fastify = require('fastify')
 const fastifyMongo = require('./index')
 
@@ -47,7 +47,7 @@ test('{ url: MONGODB_URL }', t => {
   })
 })
 
-test('{ url: MULTIMONGODB_URL }', t => {
+skip('{ url: MULTIMONGODB_URL }', t => {
   t.plan(6 + 4 + 2 + 2)
 
   register(t, { url: MULTIMONGODB_URL }, function (err, fastify) {
@@ -201,7 +201,8 @@ test('{ url: MONGODB_URL, database: ANOTHER_DATABASE_NAME }', t => {
 test('{ client: client }', t => {
   t.plan(5 + 4 + 2)
 
-  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL)
+  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL,
+    { useNewUrlParser: true })
     .then(client => {
       t.teardown(client.close.bind(client))
       register(t, { client: client }, function (err, fastify) {
@@ -221,7 +222,8 @@ test('{ client: client }', t => {
 test('{ client: client, database: DATABASE_NAME }', t => {
   t.plan(6 + 4 + 2 + 2)
 
-  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL)
+  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL,
+    { useNewUrlParser: true })
     .then(client => {
       t.teardown(client.close.bind(client))
       register(t, { client: client, database: ANOTHER_DATABASE_NAME }, function (err, fastify) {
@@ -243,7 +245,8 @@ test('{ client: client, database: DATABASE_NAME }', t => {
 test('{ client: client, name: CLIENT_NAME }', t => {
   t.plan(8 + 4 + 2 + 4 + 2)
 
-  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL)
+  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL,
+    { useNewUrlParser: true })
     .then(client => {
       t.teardown(client.close.bind(client))
       register(t, { client: client, name: CLIENT_NAME }, function (err, fastify) {
@@ -270,7 +273,8 @@ test('{ client: client, name: CLIENT_NAME }', t => {
 test('{ client: client, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }', t => {
   t.plan(10 + 4 + 2 + 2 + 4 + 2 + 2)
 
-  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL)
+  mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL,
+    { useNewUrlParser: true })
     .then(client => {
       t.teardown(client.close.bind(client))
       register(t, { client: client, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }, function (err, fastify) {
@@ -300,7 +304,8 @@ test('{ client: client, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }', t
 
 test('{ client: client } does not set onClose', t => {
   const fastify = Fastify()
-  return mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL)
+  return mongodb.MongoClient.connect(NO_DATABASE_MONGODB_URL,
+    { useNewUrlParser: true })
     .then(client => {
       fastify.register(fastifyMongo, { client, database: DATABASE_NAME })
       return fastify.ready()
@@ -331,7 +336,7 @@ test('{ url: "unknown://protocol" }', t => {
   t.plan(2)
   register(t, { url: 'unknown://protocol' }, function (err, fastify) {
     t.ok(err)
-    t.ok(/Invalid schema/.test(err.message))
+    t.match(err.message, /Invalid connection string/)
   })
 })
 


### PR DESCRIPTION
This is an attempt to solve #51 which stalled since #52 
It seems this is a parallel PR (sorry for this) with #59 in terms of goals, but it follows a quite different approach.

With this PR the mutimongo url test is skipped:
https://github.com/lependu/fastify-mongodb/blob/da1d7319fd85b898ff15b0e1a255a95c4c4eb830/test.js#L50

It seems the hard part of testing multi url connection is that the best of my knowledge `3.1.x` driver requires setting up replicasets for this. Please, corret me if I wrong, the documentation is quite confusing.

If I am right, I have a [setup](https://github.com/lependu/test-mongo-travis-replicaset/blob/fastify-mongodb/.travis.yml) to test it with travis, but it would make the local testing pretty complicated:
- requires to set up multiple mongodb instances
- initiate replicaset 
- network setup which may differ depending how and on what OS we run mongo server instances.

If you think this worth the effort, and there is no simplier approach,  I happy to add the replicaset testing too.
