### PR TITLE
Fix ObjectId interface to be compatible with bson typescript definitions.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare namespace fastifyMongodb {
     /**
      * Mongo ObjectId class
      */
-    ObjectId: mongodb.ObjectId;
+    ObjectId: typeof mongodb.ObjectId;
   }
 
   interface FastifyMongoNestedObject {

--- a/types.test.ts
+++ b/types.test.ts
@@ -13,4 +13,5 @@ app
     const dbTest = app.mongo.client.db('test');
     const dbDb = app.mongo.db!;
     const ObjectId = app.mongo.ObjectId;
+    const myId = new ObjectId('aaaa');
   });


### PR DESCRIPTION
After some playing with `bson` and `mongodb` types I've find out that in TS it's not possible to use `ObjectId('...')` shorthand like in plain javascript. Usual way to do that in TS is to use `new ObjectId('...')` unless it's overridden in user's code to function.

For now it's also impossible to define two types `class` and `function` due typescript bug. When it will be fixed, the original code will work. Unless we need that `typeof` and use it like class (see modified types test file).