### PR TITLE
onClose handler does not support promise in fastify@2.0.0-rc6

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function decorateFastifyInstance (fastify, client, options, next) {
 
   if (newClient) {
     // done() is not needed because .close() returns a Promise
-    fastify.addHook('onClose', (fastify) => client.close(forceClose))
+    fastify.addHook('onClose', () => client.close(forceClose))
   }
 
   const mongo = {


### PR DESCRIPTION
Tests are failing with fastify@next (tested with 2.0.0-rc4 and 2.0.0-rc6). Looks like `onClose` handler must call `done()` now and returning promises (or async fn) no longer works.