### PR TITLE
Passing optional settings for MongoClient to the plugin

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,10 @@ declare namespace fastifyMongodb {
      * Connection url
      */
     url?: string;
+    /**
+     * Optional MongoClient settings
+     */
+    optionalSettings?: object;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -85,6 +85,12 @@ function fastifyMongodb (fastify, options, next) {
   const parsedDbName = urlTokens && urlTokens[1]
   const databaseName = database || parsedDbName
 
+  const optionalSettings = options.optionalSettings
+  delete options.optionalSettings
+  if(optionalSettings){
+    options = Object.assign(extraOptions, options)
+  }
+  
   MongoClient.connect(url, options, function onConnect (err, client) {
     if (err) {
       next(err)

--- a/index.js
+++ b/index.js
@@ -87,10 +87,10 @@ function fastifyMongodb (fastify, options, next) {
 
   const optionalSettings = options.optionalSettings
   delete options.optionalSettings
-  if(optionalSettings){
-    options = Object.assign(extraOptions, options)
+  if (optionalSettings) {
+    options = Object.assign(optionalSettings, options)
   }
-  
+
   MongoClient.connect(url, options, function onConnect (err, client) {
     if (err) {
       next(err)


### PR DESCRIPTION
The Plugin has no way to pass optional settings to `MongoClient.connect` in the `fastifyMongodb` function without pre-configuring the instance and passing the connected client. Ive added an optional field that you can pass any extra settings to the `fastifyMongodb` function and add it to the `MongoClient.connect` options. [Here](http://mongodb.github.io/node-mongodb-native/3.6/api/MongoClient.html) you can see all the optional settings that could be added.
Example use:
```
import mongodb from "fastify-mongodb";

server.register(mongodb, {
    forceClose: true,
    url: mongoUri
    optionalSettings: {
        sslCA: ca,
        checkServerIdentity: false,
    },
});
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
