### PR TITLE
feat: re-export ObjectId from mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ following properties:
 - `ObjectId` is the [`ObjectId` class](http://mongodb.github.io/node-mongodb-native/3.3/api/ObjectID.html)
 - `db` is the [`DB` instance](http://mongodb.github.io/node-mongodb-native/3.3/api/Db.html)
 
+The `ObjectId` class can also be directly imported from the plugin as it gets re-exported from `mongodb`:
+
+```js
+const { ObjectId } = require('fastify-mongodb')
+
+const id = new ObjectId('some-id-here')
+```
+
 The `db` property is added **only if**:
 - a `database` string option is given during the plugin registration.
 - the connection string contains the database name. See the [Connection String URI Format](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-uri-format)

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginCallback } from 'fastify';
-import type { Db, MongoClient, ObjectId, MongoClientOptions } from 'mongodb';
+import type { Db, MongoClient, MongoClientOptions } from 'mongodb';
+import { ObjectId } from 'mongodb';
 
 export interface FastifyMongoObject {
   /**
@@ -50,3 +51,5 @@ declare module 'fastify' {
 export const fastifyMongodb: FastifyPluginCallback<FastifyMongodbOptions>;
 
 export default fastifyMongodb;
+
+export { ObjectId };

--- a/index.js
+++ b/index.js
@@ -1,10 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const MongoDb = require('mongodb')
-
-const MongoClient = MongoDb.MongoClient
-const ObjectId = MongoDb.ObjectId
+const { MongoClient, ObjectId } = require('mongodb')
 
 function decorateFastifyInstance (fastify, client, options, next) {
   const forceClose = options.forceClose
@@ -104,3 +101,5 @@ module.exports = fp(fastifyMongodb, {
   fastify: '>=1.0.0',
   name: 'fastify-mongodb'
 })
+
+module.exports.ObjectId = ObjectId;

--- a/index.js
+++ b/index.js
@@ -102,4 +102,4 @@ module.exports = fp(fastifyMongodb, {
   name: 'fastify-mongodb'
 })
 
-module.exports.ObjectId = ObjectId;
+module.exports.ObjectId = ObjectId

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import fastify from 'fastify';
-import fastifyMongodb from '../fastify-mongodb';
+import fastifyMongodb, { ObjectId as reExportedObjectId } from '../fastify-mongodb';
 
 const app = fastify();
 
@@ -14,4 +14,5 @@ app
     const dbDb = app.mongo.db!;
     const ObjectId = app.mongo.ObjectId;
     const myId = new ObjectId('aaaa');
+    const myId2 = new reExportedObjectId('aaaa');
   });

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ const t = require('tap')
 const { test } = t
 const Fastify = require('fastify')
 const fastifyMongo = require('./index')
+const { ObjectId } = require('./index')
 
 const mongodb = require('mongodb')
 
@@ -13,6 +14,18 @@ const MONGODB_URL = 'mongodb://127.0.0.1/' + DATABASE_NAME
 const CLIENT_NAME = 'client_name'
 const ANOTHER_DATABASE_NAME = 'my_awesome_database'
 const COLLECTION_NAME = 'mycoll'
+
+test('re-export ObjectId', t => {
+  t.plan(4)
+
+  testObjectId(t, fastifyMongo.ObjectId)
+})
+
+test('re-export ObjectId destructured', t => {
+  t.plan(4)
+
+  testObjectId(t, ObjectId)
+})
 
 test('{ url: NO_DATABASE_MONGODB_URL }', t => {
   t.plan(5 + 4 + 2)


### PR DESCRIPTION
Closes: #138

This PR re-exports the `ObjectId` from `mongodb`. `ObjectId('id')` should work for JS users but TS users will have to create an instance to do the same i.e. `new ObjectId('id')`. The compiler will complain if you don't use the `new` keyword even tho it works at runtime if you ignore the error.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
