### PR TITLE
ci: drop support of node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [12, 14, 16]
 
     services:
       mongodb:


### PR DESCRIPTION
As `mongodb` drop support of `node@10` for `mongodb@4`, our CI should follow the same. Otherwise, it will always fail.

I think it is not a major to drop support as it should be dropped since https://github.com/fastify/fastify-mongodb/commit/e956cc4a59356702c6816ea4463b05f02d31926b

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
