### PR TITLE
fix: timeout after avvio

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Notes:
 * the passed `client` connection will **not** be closed when the Fastify server
 shuts down.
 * in order to terminate the MongoDB connection you have to manually call the [fastify.close](https://www.fastify.io/docs/latest/Server/#close) method (for example for testing purposes, otherwise the test will hang).
-* server connection timeout is reduce from 30s (default) to 7.5s in order throw error before `fastify` plugin timeout.
+* `mongodb` connection timeout is reduce from 30s (default) to 7.5s in order throw error before `fastify` plugin timeout.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Notes:
 * the passed `client` connection will **not** be closed when the Fastify server
 shuts down.
 * in order to terminate the MongoDB connection you have to manually call the [fastify.close](https://www.fastify.io/docs/latest/Server/#close) method (for example for testing purposes, otherwise the test will hang).
+* server connection timeout is reduce from 30s (default) to 7.5s in order throw error before `fastify` plugin timeout.
 
 ## Reference
 

--- a/index.js
+++ b/index.js
@@ -48,8 +48,7 @@ function decorateFastifyInstance (fastify, client, options, next) {
 
 function fastifyMongodb (fastify, options, next) {
   options = Object.assign({
-    useNewUrlParser: true,
-    useUnifiedTopology: true
+    serverSelectionTimeoutMS: 7500
   }, options)
 
   const forceClose = options.forceClose

--- a/test.js
+++ b/test.js
@@ -421,6 +421,20 @@ test('Immutable options', t => {
   })
 })
 
+test('timeout', t => {
+  t.plan(1)
+
+  const fastify = Fastify()
+  t.teardown(() => fastify.close())
+
+  fastify
+    .register(fastifyMongo, { url: 'mongodb://127.0.0.1:9999' })
+    .ready(err => {
+      t.ok(err)
+      t.equal(err.message, 'MongoServerSelectionError: connect ECONNREFUSED 127.0.0.1:9999')
+    })
+})
+
 function register (t, options, callback) {
   const fastify = Fastify()
   t.teardown(() => fastify.close())

--- a/test.js
+++ b/test.js
@@ -422,7 +422,7 @@ test('Immutable options', t => {
 })
 
 test('timeout', t => {
-  t.plan(1)
+  t.plan(2)
 
   const fastify = Fastify()
   t.teardown(() => fastify.close())

--- a/test.js
+++ b/test.js
@@ -431,7 +431,7 @@ test('timeout', t => {
     .register(fastifyMongo, { url: 'mongodb://127.0.0.1:9999' })
     .ready(err => {
       t.ok(err)
-      t.equal(err.message, 'MongoServerSelectionError: connect ECONNREFUSED 127.0.0.1:9999')
+      t.equal(err.message, 'connect ECONNREFUSED 127.0.0.1:9999')
     })
 })
 


### PR DESCRIPTION
Fixes #134 

Finally, I found the right option for connection timeout.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
