### PR TITLE
feat!: support mongodb@6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-mongo.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci-mongo.yml@7993e1ea858b5c3ceff1aa154fa44b892f311ac3
     with:
       lint: true
       license-check: true

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fastify MongoDB connection plugin; with this you can share the same MongoDB conn
 
 Under the hood the official [MongoDB](https://github.com/mongodb/node-mongodb-native) driver is used,
 the options that you pass to `register` will be passed to the Mongo client.
-The `mongodb` driver is v5.x.x.
+The `mongodb` driver is v6.x.x.
 
 If you do not provide the client by yourself (see below), the URL option is *required*.
 

--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^20.1.0",
-    "fastify": "^4.0.0-rc.3",
+    "fastify": "^4.0.0",
     "standard": "^17.0.0",
     "tap": "^16.1.0",
     "tsd": "^0.28.0"
   },
   "dependencies": {
     "fastify-plugin": "^4.0.0",
-    "mongodb": "^5.0.0"
+    "mongodb": "^6.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Refs https://github.com/mongodb/node-mongodb-native/releases/tag/v6.0.0
Refs https://github.com/fastify/workflows/pull/92

It is a BREAKING CHANGE which drop support for `node@14`, the same as the mongodb driver.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
