### PR TITLE
Update for Fastify v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-mongo.yml@7993e1ea858b5c3ceff1aa154fa44b892f311ac3
+    uses: fastify/workflows/.github/workflows/plugins-ci-mongo.yml@v4.1.0
     with:
       lint: true
       license-check: true

--- a/.taprc
+++ b/.taprc
@@ -1,2 +1,3 @@
+disable-coverage: true
 files:
   - 'test/**/*.test.js'

--- a/.taprc
+++ b/.taprc
@@ -1,3 +1,2 @@
-disable-coverage: true
 files:
   - 'test/**/*.test.js'

--- a/package.json
+++ b/package.json
@@ -32,16 +32,16 @@
   },
   "homepage": "https://github.com/fastify/fastify-mongodb#readme",
   "devDependencies": {
-    "@fastify/pre-commit": "^2.0.2",
-    "@types/node": "^20.6.2",
-    "fastify": "^4.23.2",
+    "@fastify/pre-commit": "^2.1.0",
+    "@types/node": "^20.11.30",
+    "fastify": "^4.26.2",
     "standard": "^17.1.0",
-    "tap": "^16.1.0",
-    "tsd": "^0.30.0"
+    "tap": "^18.7.1",
+    "tsd": "^0.30.7"
   },
   "dependencies": {
     "fastify-plugin": "^4.5.1",
-    "mongodb": "^6.1.0"
+    "mongodb": "^6.5.0"
   },
   "publishConfig": {
     "access": "public"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,8 +16,7 @@ const CLIENT_NAME = 'client_name'
 const ANOTHER_DATABASE_NAME = 'my_awesome_database'
 const COLLECTION_NAME = 'mycoll'
 
-
-function objectIdTest(t, ObjectId, message) {
+function objectIdTest (t, ObjectId, message) {
   message = message || 'expect ObjectId value'
 
   const obj1 = new ObjectId()
@@ -31,7 +30,7 @@ function objectIdTest(t, ObjectId, message) {
   t.ok(!obj1.equals(obj3))
 }
 
-function clientTest(t, client, message) {
+function clientTest (t, client, message) {
   message = message || 'expect client'
   const db = client.db(DATABASE_NAME)
 
@@ -43,7 +42,7 @@ function clientTest(t, client, message) {
   }, message)
 }
 
-function databaseTest(t, db, message) {
+function databaseTest (t, db, message) {
   message = message || 'expect database'
 
   const col = db.collection(COLLECTION_NAME)
@@ -439,7 +438,6 @@ test('timeout', async (t) => {
     t.equal(err.message, 'connect ECONNREFUSED 127.0.0.1:9999')
   }
 })
-
 
 async function register (t, options) {
   const fastify = Fastify()

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,6 +17,7 @@ const ANOTHER_DATABASE_NAME = 'my_awesome_database'
 const COLLECTION_NAME = 'mycoll'
 
 function objectIdTest (t, ObjectId, message) {
+  t.plan(4)
   message = message || 'expect ObjectId value'
 
   const obj1 = new ObjectId()
@@ -31,6 +32,7 @@ function objectIdTest (t, ObjectId, message) {
 }
 
 function clientTest (t, client, message) {
+  t.plan(1)
   message = message || 'expect client'
   const db = client.db(DATABASE_NAME)
 
@@ -43,6 +45,7 @@ function clientTest (t, client, message) {
 }
 
 function databaseTest (t, db, message) {
+  t.plan(1)
   message = message || 'expect database'
 
   const col = db.collection(COLLECTION_NAME)

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,55 +16,52 @@ const CLIENT_NAME = 'client_name'
 const ANOTHER_DATABASE_NAME = 'my_awesome_database'
 const COLLECTION_NAME = 'mycoll'
 
-t.Test.prototype.addAssert('objectId', 1, function (ObjectId, message, extra) {
+
+function objectIdTest(t, ObjectId, message) {
   message = message || 'expect ObjectId value'
 
   const obj1 = new ObjectId()
-  assert.ok(obj1)
+  t.ok(obj1)
 
   const obj2 = new ObjectId(obj1)
-  assert.ok(obj2)
-  assert.ok(obj1.equals(obj2))
+  t.ok(obj2)
+  t.ok(obj1.equals(obj2))
 
   const obj3 = new ObjectId()
-  assert.ok(!obj1.equals(obj3))
+  t.ok(!obj1.equals(obj3))
+}
 
-  return this.pass(message)
-})
-
-t.Test.prototype.addAssert('client', 1, function (client, message, extra) {
+function clientTest(t, client, message) {
   message = message || 'expect client'
   const db = client.db(DATABASE_NAME)
 
   const col = db.collection(COLLECTION_NAME)
 
-  return this.resolves(async () => {
+  t.resolves(async () => {
     const r = await col.insertMany([{ a: 1 }])
     assert.strictEqual(1, r.insertedCount)
-  }, message, extra)
-})
+  }, message)
+}
 
-t.Test.prototype.addAssert('database', 1, function (db, message, extra) {
+function databaseTest(t, db, message) {
   message = message || 'expect database'
 
   const col = db.collection(COLLECTION_NAME)
 
-  return this.resolves(async () => {
+  t.resolves(async () => {
     const r = await col.insertMany([{ a: 1 }])
     assert.deepEqual(1, r.insertedCount)
-  }, message, extra)
-})
+  }, message)
+}
 
 test('re-export ObjectId', async (t) => {
   t.plan(1)
-
-  t.objectId(fastifyMongo.ObjectId)
+  t.test(async t => objectIdTest(t, fastifyMongo.ObjectId))
 })
 
 test('re-export ObjectId destructured', async (t) => {
   t.plan(1)
-
-  t.objectId(ObjectId)
+  t.test(async t => objectIdTest(t, ObjectId))
 })
 
 test('export of mongodb', async (t) => {
@@ -83,8 +80,8 @@ test('{ url: NO_DATABASE_MONGODB_URL }', async (t) => {
   t.ok(fastify.mongo.ObjectId)
   t.notOk(fastify.mongo.db)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
 })
 
 test('{ url: MONGODB_URL }', async (t) => {
@@ -97,9 +94,9 @@ test('{ url: MONGODB_URL }', async (t) => {
   t.ok(fastify.mongo.db)
   t.equal(fastify.mongo.db.databaseName, DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 })
 
 test('{ url: NO_DATABASE_MONGODB_URL, name: CLIENT_NAME }', async (t) => {
@@ -115,11 +112,11 @@ test('{ url: NO_DATABASE_MONGODB_URL, name: CLIENT_NAME }', async (t) => {
   t.ok(fastify.mongo[CLIENT_NAME].ObjectId)
   t.notOk(fastify.mongo[CLIENT_NAME].db)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
 
-  t.objectId(fastify.mongo[CLIENT_NAME].ObjectId)
-  t.client(fastify.mongo[CLIENT_NAME].client)
+  t.test(async t => objectIdTest(t, fastify.mongo[CLIENT_NAME].ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo[CLIENT_NAME].client))
 })
 
 test('{ url: MONGODB_URL, name: CLIENT_NAME }', async (t) => {
@@ -137,13 +134,13 @@ test('{ url: MONGODB_URL, name: CLIENT_NAME }', async (t) => {
   t.ok(fastify.mongo[CLIENT_NAME].db)
   t.equal(fastify.mongo[CLIENT_NAME].db.databaseName, DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 
-  t.objectId(fastify.mongo[CLIENT_NAME].ObjectId)
-  t.client(fastify.mongo[CLIENT_NAME].client)
-  t.database(fastify.mongo[CLIENT_NAME].db)
+  t.test(async t => objectIdTest(t, fastify.mongo[CLIENT_NAME].ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo[CLIENT_NAME].client))
+  t.test(async t => databaseTest(t, fastify.mongo[CLIENT_NAME].db))
 })
 
 test('{ url: NO_DATABASE_MONGODB_URL, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }', async (t) => {
@@ -161,13 +158,13 @@ test('{ url: NO_DATABASE_MONGODB_URL, name: CLIENT_NAME, database: ANOTHER_DATAB
   t.ok(fastify.mongo[CLIENT_NAME].db)
   t.equal(fastify.mongo[CLIENT_NAME].db.databaseName, ANOTHER_DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 
-  t.objectId(fastify.mongo[CLIENT_NAME].ObjectId)
-  t.client(fastify.mongo[CLIENT_NAME].client)
-  t.database(fastify.mongo[CLIENT_NAME].db)
+  t.test(async t => objectIdTest(t, fastify.mongo[CLIENT_NAME].ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo[CLIENT_NAME].client))
+  t.test(async t => databaseTest(t, fastify.mongo[CLIENT_NAME].db))
 })
 
 test('{ url: MONGODB_URL, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }', async (t) => {
@@ -185,13 +182,13 @@ test('{ url: MONGODB_URL, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }',
   t.ok(fastify.mongo[CLIENT_NAME].db)
   t.equal(fastify.mongo[CLIENT_NAME].db.databaseName, ANOTHER_DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 
-  t.objectId(fastify.mongo[CLIENT_NAME].ObjectId)
-  t.client(fastify.mongo[CLIENT_NAME].client)
-  t.database(fastify.mongo[CLIENT_NAME].db)
+  t.test(async t => objectIdTest(t, fastify.mongo[CLIENT_NAME].ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo[CLIENT_NAME].client))
+  t.test(async t => databaseTest(t, fastify.mongo[CLIENT_NAME].db))
 })
 
 test('{ url: NO_DATABASE_MONGODB_URL, database: ANOTHER_DATABASE_NAME }', async (t) => {
@@ -204,9 +201,9 @@ test('{ url: NO_DATABASE_MONGODB_URL, database: ANOTHER_DATABASE_NAME }', async 
   t.ok(fastify.mongo.db)
   t.equal(fastify.mongo.db.databaseName, ANOTHER_DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 })
 
 test('{ url: MONGODB_URL, database: ANOTHER_DATABASE_NAME }', async (t) => {
@@ -219,9 +216,9 @@ test('{ url: MONGODB_URL, database: ANOTHER_DATABASE_NAME }', async (t) => {
   t.ok(fastify.mongo.db)
   t.equal(fastify.mongo.db.databaseName, ANOTHER_DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 })
 
 test('{ client: client }', async (t) => {
@@ -236,8 +233,8 @@ test('{ client: client }', async (t) => {
   t.ok(fastify.mongo.ObjectId)
   t.notOk(fastify.mongo.db)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
 })
 
 test('{ client: client, database: DATABASE_NAME }', async (t) => {
@@ -253,9 +250,9 @@ test('{ client: client, database: DATABASE_NAME }', async (t) => {
   t.ok(fastify.mongo.db)
   t.equal(fastify.mongo.db.databaseName, ANOTHER_DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 })
 
 test('{ client: client, name: CLIENT_NAME }', async (t) => {
@@ -274,11 +271,11 @@ test('{ client: client, name: CLIENT_NAME }', async (t) => {
   t.ok(fastify.mongo[CLIENT_NAME].ObjectId)
   t.notOk(fastify.mongo[CLIENT_NAME].db)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
 
-  t.objectId(fastify.mongo[CLIENT_NAME].ObjectId)
-  t.client(fastify.mongo[CLIENT_NAME].client)
+  t.test(async t => objectIdTest(t, fastify.mongo[CLIENT_NAME].ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo[CLIENT_NAME].client))
 })
 
 test('{ client: client, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }', async (t) => {
@@ -299,13 +296,13 @@ test('{ client: client, name: CLIENT_NAME, database: ANOTHER_DATABASE_NAME }', a
   t.ok(fastify.mongo[CLIENT_NAME].db)
   t.equal(fastify.mongo[CLIENT_NAME].db.databaseName, ANOTHER_DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 
-  t.objectId(fastify.mongo[CLIENT_NAME].ObjectId)
-  t.client(fastify.mongo[CLIENT_NAME].client)
-  t.database(fastify.mongo[CLIENT_NAME].db)
+  t.test(async t => objectIdTest(t, fastify.mongo[CLIENT_NAME].ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo[CLIENT_NAME].client))
+  t.test(async t => databaseTest(t, fastify.mongo[CLIENT_NAME].db))
 })
 
 test('{ client: client } does not set onClose', async (t) => {
@@ -317,7 +314,7 @@ test('{ client: client } does not set onClose', async (t) => {
   await fastify.ready()
   await fastify.close()
 
-  t.database(fastify.mongo.db)
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 })
 
 test('{ }', async (t) => {
@@ -385,17 +382,17 @@ test('double register with different name', async (t) => {
   t.ok(fastify.mongo.client2.db)
   t.equal(fastify.mongo.client2.db.databaseName, ANOTHER_DATABASE_NAME)
 
-  t.objectId(fastify.mongo.ObjectId)
-  t.client(fastify.mongo.client)
-  t.database(fastify.mongo.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client))
+  t.test(async t => databaseTest(t, fastify.mongo.db))
 
-  t.objectId(fastify.mongo.client1.ObjectId)
-  t.client(fastify.mongo.client1.client)
-  t.database(fastify.mongo.client1.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.client1.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client1.client))
+  t.test(async t => databaseTest(t, fastify.mongo.client1.db))
 
-  t.objectId(fastify.mongo.client2.ObjectId)
-  t.client(fastify.mongo.client2.client)
-  t.database(fastify.mongo.client2.db)
+  t.test(async t => objectIdTest(t, fastify.mongo.client2.ObjectId))
+  t.test(async t => clientTest(t, fastify.mongo.client2.client))
+  t.test(async t => databaseTest(t, fastify.mongo.client2.db))
 })
 
 test('double register with the same name', async (t) => {
@@ -442,6 +439,7 @@ test('timeout', async (t) => {
     t.equal(err.message, 'connect ECONNREFUSED 127.0.0.1:9999')
   }
 })
+
 
 async function register (t, options) {
   const fastify = Fastify()


### PR DESCRIPTION
Ref: https://github.com/fastify/fastify/issues/5116

- this PR replaces the embedded custom plugin in favor of 3 functions (maintaining the same structure inside) (tap 18 requires its plugins to be loaded from `node_modules`)
- considering the above change, I've replaced the plugin with subtests (that do not need a repetitive title) which will run the assertion function just as before

⚠️ ~~Not sure about the version of CI used for this repo. Currently is set to:~~
```
fastify/workflows/.github/workflows/plugins-ci-mongo.yml@7993e1ea858b5c3ceff1aa154fa44b892f311ac3
```
☝️ used version `v4.1.0`

~~Can anyone confirm that there's a newer version for deploying for this repo?~~

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

CC @simoneb 