### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.12.0",
     "tsd": "^0.31.0"


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.