### PR TITLE
chore: update readme and scripts coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,18 @@ Fastify MongoDB connection plugin; with this you can share the same MongoDB conn
 
 Under the hood the official [MongoDB](https://github.com/mongodb/node-mongodb-native) driver is used,
 the options that you pass to `register` will be passed to the Mongo client.
-The `mongodb` driver is v6.x.x.
+The `mongodb` driver is v7.x.x.
 
 If you do not provide the client by yourself (see below), the URL option is *required*.
 
 ## Install
 
-```
+```bash
 npm i @fastify/mongodb
 ```
 
 ## Usage
+
 Add it to your project with `register` and you are done!
 
 ```js
@@ -74,6 +75,7 @@ mongodb.MongoClient.connect('mongodb://mongo/db')
 ```
 
 Notes:
+
 * the passed `client` connection will **not** be closed when the Fastify server
 shuts down.
 * to terminate the MongoDB connection you have to manually call the [fastify.close](https://fastify.dev/docs/latest/Reference/Server/#close) method (for example for testing purposes, otherwise the test will hang).
@@ -84,9 +86,9 @@ shuts down.
 This plugin decorates the `fastify` instance with a `mongo` object. That object has the
 following properties:
 
-- `client` is the [`MongoClient` instance](http://mongodb.github.io/node-mongodb-native/3.3/api/MongoClient.html)
-- `ObjectId` is the [`ObjectId` class](http://mongodb.github.io/node-mongodb-native/3.3/api/ObjectID.html)
-- `db` is the [`DB` instance](http://mongodb.github.io/node-mongodb-native/3.3/api/Db.html)
+* `client` is the [`MongoClient` instance](http://mongodb.github.io/node-mongodb-native/3.3/api/MongoClient.html)
+* `ObjectId` is the [`ObjectId` class](http://mongodb.github.io/node-mongodb-native/3.3/api/ObjectID.html)
+* `db` is the [`DB` instance](http://mongodb.github.io/node-mongodb-native/3.3/api/Db.html)
 
 The `ObjectId` class can also be directly imported from the plugin as it gets re-exported from `mongodb`:
 
@@ -97,8 +99,9 @@ const id = new ObjectId('some-id-here')
 ```
 
 The `db` property is added **only if**:
-- a `database` string option is given during the plugin registration.
-- the connection string contains the database name. See the [Connection String URI Format](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-uri-format)
+
+* a `database` string option is given during the plugin registration.
+* the connection string contains the database name. See the [Connection String URI Format](https://docs.mongodb.com/manual/reference/connection-string/#connection-string-uri-format)
 
 A `name` option can be used to connect to multiple MongoDB clusters.
 
@@ -126,8 +129,9 @@ fastify.get('/', function (req, res) {
 ## Acknowledgments
 
 This project is kindly sponsored by:
-- [nearForm](https://nearform.com)
-- [LetzDoIt](https://www.letzdoitapp.com/)
+
+* [nearForm](https://nearform.com)
+* [LetzDoIt](https://www.letzdoitapp.com/)
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "type": "commonjs",
   "types": "types/index.d.ts",
   "scripts": {
-    "coverage": "npm run unit -- --cov --coverage-report=html",
+    "coverage": "c8 --reporter=html node --test",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "mongo": "docker run --rm -d -p 27017:27017 mongo:5.0.0",
+    "mongo": "docker run --rm -d -p 27017:27017 mongo:8.0.0",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
     "test:unit": "c8 --100 node --test"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
-->

Proposals:

- **README.md**: Updated documentation description, links and formatting
- **package.json**: 
  - Updated `MongoDB Docker` image to version `8.0.0`
  - Fixed `coverage` script to use `c8` directly instead of `npm run unit` (previous implementation was not generating coverage reports correctly)
